### PR TITLE
Allow guzzlephp/guzzle ^7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,31 @@ php:
 - 7.4
 - nightly
 
+env:
+- GUZZLE_VERSION=^6.3
+
 matrix:
     fast_finish: true
     allow_failures:
     - php: nightly
+    include:
+    - php: 7.2
+      env: GUZZLE_VERSION=^7.0
+    - php: 7.3
+      env: GUZZLE_VERSION=^7.0
+    - php: 7.4
+      env: GUZZLE_VERSION=^7.0
+    - php: nightly
+      env: GUZZLE_VERSION=^7.0
 
 sudo: false
 
 cache:
     directories:
     - $HOME/.composer/cache
+
+before_install:
+- composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
 
 install:
 - travis_retry composer install --no-interaction --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "moneyphp/money": "^3.0",
         "myclabs/php-enum": "^1.6",
         "psr/cache": "^1.0",

--- a/src/Secure/BaseConnection.php
+++ b/src/Secure/BaseConnection.php
@@ -126,7 +126,7 @@ abstract class BaseConnection implements ConnectionInterface
             } else if ($response->getStatusCode() === 401) {
                 throw SnelstartApiAccessDeniedException::createFromParent($clientException);
             } else if ($response->getStatusCode() === 403) {
-                throw new SnelstartApiAccessDeniedException($response->getReasonPhrase(), $request);
+                throw new SnelstartApiAccessDeniedException($response->getReasonPhrase(), $request, $response);
             } else if ($response->getStatusCode() === 404) {
                 $body = (string) $response->getBody();
 


### PR DESCRIPTION
These changes allow the package to be used with guzzlephp/guzzle ^7.0. The travis config has also been updated to ensure the tests are running for both versions of guzzle.

To prevent the build from failing I've also updated an issue that was brought up by phpstan.