### PR TITLE
Allow ramsey/uuid ^4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ php:
 - nightly
 
 env:
-    - GUZZLE_VERSION=^6.3
-    - UUID_VERSION=^3.8
+    - GUZZLE_VERSION=^6.3 UUID_VERSION=^3.8
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,15 @@ matrix:
     - php: nightly
     include:
         - php: 7.2
-          env:
-              - GUZZLE_VERSION=^7.0
-              - UUID_VERSION=^4.0
+          env: GUZZLE_VERSION=^7.0 UUID_VERSION=^4.0
+        - php: 7.2
+          env: GUZZLE_VERSION=^7.0 UUID_VERSION=^4.0
         - php: 7.3
-          env:
-              - GUZZLE_VERSION=^7.0
-              - UUID_VERSION=^4.0
+          env: GUZZLE_VERSION=^7.0 UUID_VERSION=^4.0
         - php: 7.4
-          env:
-              - GUZZLE_VERSION=^7.0
-              - UUID_VERSION=^4.0
+          env: GUZZLE_VERSION=^7.0 UUID_VERSION=^4.0
         - php: nightly
-          env:
-              - GUZZLE_VERSION=^7.0
-              - UUID_VERSION=^4.0
+          env: GUZZLE_VERSION=^7.0 UUID_VERSION=^4.0
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,41 @@ php:
 - 7.4
 - nightly
 
+env:
+    - GUZZLE_VERSION=^6.3
+    - UUID_VERSION=^3.8
+
 matrix:
     fast_finish: true
     allow_failures:
     - php: nightly
+    include:
+        - php: 7.2
+          env:
+              - GUZZLE_VERSION=^7.0
+              - UUID_VERSION=^4.0
+        - php: 7.3
+          env:
+              - GUZZLE_VERSION=^7.0
+              - UUID_VERSION=^4.0
+        - php: 7.4
+          env:
+              - GUZZLE_VERSION=^7.0
+              - UUID_VERSION=^4.0
+        - php: nightly
+          env:
+              - GUZZLE_VERSION=^7.0
+              - UUID_VERSION=^4.0
 
 sudo: false
 
 cache:
     directories:
     - $HOME/.composer/cache
+
+before_install:
+    - composer require "guzzlehttp/guzzle:${GUZZLE_VERSION}" --no-update
+    - composer require "ramsey/uuid:${UUID_VERSION}" --no-update
 
 install:
 - travis_retry composer install --no-interaction --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",
-        "ramsey/uuid": "^3.8"
+        "ramsey/uuid": "^3.8|^4.0"
     },
     "require-dev": {
         "dg/bypass-finals": "^1.1",


### PR DESCRIPTION
This change allows the usage of `ramsey/uuid` ^4.0.

I've also updated the travis config to run the tests against both versions of `ramsey/uuid` and the previously changed `guzzlephp/guzzle`