### PR TITLE
Added "ArtikelOmzetgroup" functionality

### DIFF
--- a/src/Connector/V2/ArtikelOmzetgroepConnector.php
+++ b/src/Connector/V2/ArtikelOmzetgroepConnector.php
@@ -9,7 +9,7 @@ namespace SnelstartPHP\Connector\V2;
 use Ramsey\Uuid\UuidInterface;
 use SnelstartPHP\Connector\BaseConnector;
 use SnelstartPHP\Exception\SnelstartResourceNotFoundException;
-use SnelstartPHP\Mapper\V2\ArtikelomzetgroepMapper;
+use SnelstartPHP\Mapper\V2\ArtikelOmzetgroepMapper;
 use SnelstartPHP\Model\V2\ArtikelOmzetgroep;
 use SnelstartPHP\Request\V2\ArtikelOmzetgroepRequest;
 
@@ -18,7 +18,7 @@ final class ArtikelOmzetgroepConnector extends BaseConnector
     public function find(UuidInterface $id): ?ArtikelOmzetgroep
     {
         try {
-            $mapper = new ArtikelomzetgroepMapper();
+            $mapper = new ArtikelOmzetgroepMapper();
             $request = new ArtikelOmzetgroepRequest();
 
             return $mapper->find($this->connection->doRequest($request->find($id)));
@@ -34,7 +34,7 @@ final class ArtikelOmzetgroepConnector extends BaseConnector
      */
     public function findAll(): iterable
     {
-        $mapper = new ArtikelomzetgroepMapper();
+        $mapper = new ArtikelOmzetgroepMapper();
         $request = new ArtikelOmzetgroepRequest();
 
         return $mapper->findAll($this->connection->doRequest($request->findAll()));

--- a/src/Connector/V2/ArtikelOmzetgroepConnector.php
+++ b/src/Connector/V2/ArtikelOmzetgroepConnector.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author  IntoWebDevelopment <info@intowebdevelopment.nl>
+ * @project SnelstartApiPHP
+ */
+
+namespace SnelstartPHP\Connector\V2;
+
+use Ramsey\Uuid\UuidInterface;
+use SnelstartPHP\Connector\BaseConnector;
+use SnelstartPHP\Exception\SnelstartResourceNotFoundException;
+use SnelstartPHP\Mapper\V2\ArtikelomzetgroepMapper;
+use SnelstartPHP\Model\V2\ArtikelOmzetgroep;
+use SnelstartPHP\Request\V2\ArtikelOmzetgroepRequest;
+
+final class ArtikelOmzetgroepConnector extends BaseConnector
+{
+    public function find(UuidInterface $id): ?ArtikelOmzetgroep
+    {
+        try {
+            $mapper = new ArtikelomzetgroepMapper();
+            $request = new ArtikelOmzetgroepRequest();
+
+            return $mapper->find($this->connection->doRequest($request->find($id)));
+        } catch (SnelstartResourceNotFoundException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @template T as ArtikelOmzetgroep
+     * @psalm-return \Generator<T>
+     * @return iterable
+     */
+    public function findAll(): iterable
+    {
+        $mapper = new ArtikelomzetgroepMapper();
+        $request = new ArtikelOmzetgroepRequest();
+
+        return $mapper->findAll($this->connection->doRequest($request->findAll()));
+    }
+}

--- a/src/Mapper/V2/ArtikelMapper.php
+++ b/src/Mapper/V2/ArtikelMapper.php
@@ -21,19 +21,28 @@ final class ArtikelMapper extends AbstractMapper
     public function find(ResponseInterface $response): ?Artikel
     {
         $this->setResponseData($response);
-        return $this->mapResponseToArtikelInstance(new Artikel());
+        return $this->mapResponseToArtikelModel(new Artikel());
     }
 
     public function findAll(ResponseInterface $response): \Generator
     {
         $this->setResponseData($response);
-
-        foreach ($this->responseData as $data) {
-            yield $this->mapResponseToArtikelInstance(new Artikel(), $data);
-        }
+        return $this->mapManyResultsToSubMappers();
     }
 
-    protected function mapResponseToArtikelInstance(Artikel $artikel, array $data = []): Artikel
+    public function add(ResponseInterface $response): Artikel
+    {
+        $this->setResponseData($response);
+        return $this->mapResponseToArtikelModel(new Artikel());
+    }
+
+    public function update(ResponseInterface $response): Artikel
+    {
+        $this->setResponseData($response);
+        return $this->mapResponseToArtikelModel(new Artikel());
+    }
+
+    protected function mapResponseToArtikelModel(Artikel $artikel, array $data = []): Artikel
     {
         $data = empty($data) ? $this->responseData : $data;
 
@@ -89,5 +98,17 @@ final class ArtikelMapper extends AbstractMapper
             ->setDatumTotEnMet($data["datumTotEnMet"] !== null ? new \DateTimeImmutable($data["datumTotEnMet"]) : null)
             ->setPrijsBepalingSoort(new PrijsBepalingSoort($data["prijsBepalingSoort"]))
         ;
+    }
+
+    /**
+     * Map many results to the mapper.
+     *
+     * @return \Generator
+     */
+    protected function mapManyResultsToSubMappers(): \Generator
+    {
+        foreach ($this->responseData as $artikelData) {
+            yield $this->mapResponseToArtikelModel(new Artikel(), $artikelData);
+        }
     }
 }

--- a/src/Mapper/V2/ArtikelOmzetgroepMapper.php
+++ b/src/Mapper/V2/ArtikelOmzetgroepMapper.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author  IntoWebDevelopment <info@intowebdevelopment.nl>
+ * @project SnelstartApiPHP
+ */
+
+namespace SnelstartPHP\Mapper\V2;
+
+use Psr\Http\Message\ResponseInterface;
+use Ramsey\Uuid\Uuid;
+use SnelstartPHP\Mapper\AbstractMapper;
+use SnelstartPHP\Model\SnelstartObject;
+use SnelstartPHP\Model\Type\PrijsBepalingSoort;
+use SnelstartPHP\Model\V2\Artikel;
+use SnelstartPHP\Model\V2\ArtikelOmzetgroep;
+use SnelstartPHP\Model\V2\Prijsafspraak;
+use SnelstartPHP\Model\V2\Relatie;
+use SnelstartPHP\Model\V2\SubArtikel;
+
+final class ArtikelOmzetgroepMapper extends AbstractMapper
+{
+    public function find(ResponseInterface $response): ?ArtikelOmzetgroep
+    {
+        $this->setResponseData($response);
+        return $this->mapResponseToArtikelOmzetgroepModel(new ArtikelOmzetgroep());
+    }
+
+    public function findAll(ResponseInterface $response): \Generator
+    {
+        $this->setResponseData($response);
+
+        foreach ($this->responseData as $data) {
+            yield $this->mapResponseToArtikelOmzetgroepModel(new ArtikelOmzetgroep(), $data);
+        }
+    }
+
+    protected function mapResponseToArtikelOmzetgroepModel(ArtikelOmzetgroep $artikelOmzetgroep, array $data = []): ArtikelOmzetgroep
+    {
+        $data = empty($data) ? $this->responseData : $data;
+
+        /**
+         * @var ArtikelOmzetgroep $artikelOmzetgroep
+         */
+        $artikelOmzetgroep = $this->mapArrayDataToModel($artikelOmzetgroep, $data);
+
+        return $artikelOmzetgroep;
+    }
+
+    /**
+     * Map many results to the mapper.
+     *
+     * @return \Generator
+     */
+    protected function mapManyResultsToSubMappers(): \Generator
+    {
+        foreach ($this->responseData as $artikelOmzetgroepData) {
+            yield $this->mapResponseToArtikelOmzetgroepModel(new ArtikelOmzetgroep(), $artikelOmzetgroepData);
+        }
+    }
+}

--- a/src/Request/V2/ArtikelOmzetgroepRequest.php
+++ b/src/Request/V2/ArtikelOmzetgroepRequest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author  OptiWise Technologies B.V. <info@optiwise.nl>
+ * @project SnelstartApiPHP
+ */
+
+namespace SnelstartPHP\Request\V2;
+
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
+use Ramsey\Uuid\UuidInterface;
+use SnelstartPHP\Request\BaseRequest;
+
+final class ArtikelOmzetgroepRequest extends BaseRequest
+{
+    public function findAll(): RequestInterface
+    {
+        return new Request("GET", "artikelomzetgroepen");
+    }
+
+    public function find(UuidInterface $id): RequestInterface
+    {
+        return new Request("GET", "artikelomzetgroepen/" . $id->toString());
+    }
+}


### PR DESCRIPTION
Added the required code for fetching "artikelomzetgroepen" from the Snelstart API (find & findAll).

+ Small refactored of the "ArtikelMapper" to reflect a universal code (naming) style matching "RelatieMapper"