### PR TITLE
Allow null to be returned from getWaarde

### DIFF
--- a/src/Model/NaamWaarde.php
+++ b/src/Model/NaamWaarde.php
@@ -32,7 +32,7 @@ final class NaamWaarde extends BaseObject
         return $this;
     }
 
-    public function getWaarde(): string
+    public function getWaarde(): ?string
     {
         return $this->waarde;
     }


### PR DESCRIPTION
I just ran into the problem where the value of `waarde` was returned from the SnelStart API as `null`, this caused the following type error:
`SnelstartPHP\Model\NaamWaarde::getWaarde(): Return value must be of type string, null returned`

I'm not quite sure how they ended up as `null`, but it happened after the customer made some edits to the relatie in SnelStart for Windows.

<img width="592" alt="IMG_6179" src="https://user-images.githubusercontent.com/1123887/158842620-6b9e7300-2a16-414f-bca9-e94dc9d529a5.png">
