### PR TITLE
Various bug fixes and added features

### DIFF
--- a/src/Connector/V2/BoekingConnector.php
+++ b/src/Connector/V2/BoekingConnector.php
@@ -41,7 +41,7 @@ final class BoekingConnector extends BaseConnector
         $ODataRequestData = $ODataRequestData ?? new ODataRequestData();
         $hasItems = false;
 
-        foreach ($boekingMapper->findAllInkoopboekingen($this->connection->doRequest($factuurRequest->findInkoopfacturen($ODataRequestData))) as $inkoopboeking) {
+        foreach ($boekingMapper->findAllInkoopfacturen($this->connection->doRequest($factuurRequest->findInkoopfacturen($ODataRequestData))) as $inkoopboeking) {
             $hasItems = true;
             yield $inkoopboeking;
         }

--- a/src/Connector/V2/BoekingConnector.php
+++ b/src/Connector/V2/BoekingConnector.php
@@ -32,7 +32,7 @@ final class BoekingConnector extends BaseConnector
     }
 
     /**
-     * @return iterable<Model\Inkoopboeking>
+     * @return iterable<Model\Inkoopfactuur>
      */
     public function findInkoopfacturen(?ODataRequestDataInterface $ODataRequestData = null, bool $fetchAll = false, iterable $previousResults = null): iterable
     {
@@ -118,7 +118,7 @@ final class BoekingConnector extends BaseConnector
     }
 
     /**
-     * @return iterable<Model\Verkoopboeking>
+     * @return iterable<Model\Verkoopfactuur>
      */
     public function findVerkoopfacturen(?ODataRequestDataInterface $ODataRequestData = null, bool $fetchAll = false, iterable $previousResults = null): iterable
     {

--- a/src/Connector/V2/BoekingConnector.php
+++ b/src/Connector/V2/BoekingConnector.php
@@ -63,8 +63,6 @@ final class BoekingConnector extends BaseConnector
             throw PreValidationException::unexpectedIdException();
         }
 
-        $inkoopboeking->assertInBalance();
-
         $boekingMapper = new Mapper\BoekingMapper();
         $boekingRequest = new Request\BoekingRequest();
 
@@ -138,8 +136,6 @@ final class BoekingConnector extends BaseConnector
         if ($verkoopboeking->getId() !== null) {
             throw PreValidationException::unexpectedIdException();
         }
-
-        $verkoopboeking->assertInBalance();
 
         if ($verkoopboeking->getVervaldatum() !== null && $verkoopboeking->getBetalingstermijn() === null) {
             $verkoopboeking->setBetalingstermijn((int) (new \DateTime())->diff($verkoopboeking->getVervaldatum())->format("%a"));

--- a/src/Connector/V2/BoekingConnector.php
+++ b/src/Connector/V2/BoekingConnector.php
@@ -83,6 +83,18 @@ final class BoekingConnector extends BaseConnector
         return $documentMapper->add($this->connection->doRequest($documentRequest->addInkoopBoekingDocument($document, $inkoopboeking)));
     }
 
+    public function updateInkoopboeking(Model\Inkoopboeking $inkoopboeking): Model\Inkoopboeking
+    {
+        if ($inkoopboeking->getId() === null) {
+            throw PreValidationException::shouldHaveAnIdException();
+        }
+
+        $boekingMapper = new Mapper\BoekingMapper();
+        $boekingRequest = new Request\BoekingRequest();
+
+        return $boekingMapper->updateInkoopboeking($this->connection->doRequest($boekingRequest->updateInkoopboeking($inkoopboeking)));
+    }
+
     public function findVerkoopboeking(UuidInterface $uuid): ?Model\Verkoopboeking
     {
         $boekingRequest = new Request\BoekingRequest();

--- a/src/Connector/V2/BoekingConnector.php
+++ b/src/Connector/V2/BoekingConnector.php
@@ -93,6 +93,18 @@ final class BoekingConnector extends BaseConnector
         return $boekingMapper->updateInkoopboeking($this->connection->doRequest($boekingRequest->updateInkoopboeking($inkoopboeking)));
     }
 
+    public function updateVerkoopboeking(Model\Verkoopboeking $verkoopboeking): Model\Verkoopboeking
+    {
+        if ($verkoopboeking->getId() === null) {
+            throw PreValidationException::shouldHaveAnIdException();
+        }
+
+        $boekingMapper = new Mapper\BoekingMapper();
+        $boekingRequest = new Request\BoekingRequest();
+
+        return $boekingMapper->updateVerkoopboeking($this->connection->doRequest($boekingRequest->updateVerkoopboeking($verkoopboeking)));
+    }
+
     public function findVerkoopboeking(UuidInterface $uuid): ?Model\Verkoopboeking
     {
         $boekingRequest = new Request\BoekingRequest();
@@ -115,7 +127,7 @@ final class BoekingConnector extends BaseConnector
         $ODataRequestData = $ODataRequestData ?? new ODataRequestData();
         $hasItems = false;
 
-        foreach ($boekingMapper->findAllVerkoopboekingen($this->connection->doRequest($factuurRequest->findVerkoopfacturen($ODataRequestData))) as $verkoopboeking) {
+        foreach ($boekingMapper->findAllVerkoopfacturen($this->connection->doRequest($factuurRequest->findVerkoopfacturen($ODataRequestData))) as $verkoopboeking) {
             $hasItems = true;
             yield $verkoopboeking;
         }

--- a/src/Connector/V2/KostenplaatsConnector.php
+++ b/src/Connector/V2/KostenplaatsConnector.php
@@ -47,7 +47,7 @@ final class KostenplaatsConnector extends BaseConnector
 
     public function update(Kostenplaats $kostenplaats): Kostenplaats
     {
-        if ($kostenplaats->getId() !== null) {
+        if ($kostenplaats->getId() === null) {
             throw PreValidationException::shouldHaveAnIdException();
         }
 

--- a/src/Mapper/V2/BoekingMapper.php
+++ b/src/Mapper/V2/BoekingMapper.php
@@ -37,6 +37,12 @@ final class BoekingMapper extends AbstractMapper
         yield from $this->mapManyResultsToSubMappers(Model\Inkoopboeking::class);
     }
 
+    public function findAllInkoopfacturen(ResponseInterface $response): \Generator
+    {
+        $this->setResponseData($response);
+        return $this->mapManyResultsToSubMappers(Model\Inkoopfactuur::class);
+    }
+
     public function findAllVerkoopboekingen(ResponseInterface $response): \Generator
     {
         $this->setResponseData($response);
@@ -164,6 +170,36 @@ final class BoekingMapper extends AbstractMapper
         return $verkoopfactuur;
     }
 
+    protected function mapInkoopfactuurResult(Model\Inkoopfactuur $inkoopfactuur, array $data = []): Model\Inkoopfactuur
+    {
+        $data = empty($data) ? $this->responseData : $data;
+
+        // This maps "id", "uri", "modifiedOn" and "factuurnummer".
+        $inkoopfactuur = $this->mapArrayDataToModel($inkoopfactuur, $data);
+
+        if (isset($data['relatie'])) {
+            $inkoopfactuur->setRelatie(Model\Relatie::createFromUUID(Uuid::fromString($data['relatie']['id'])));
+        }
+        if (isset($data['inkoopBoeking'])) {
+            $inkoopfactuur->setInkoopboeking(Model\Inkoopboeking::createFromUUID(Uuid::fromString($data['inkoopBoeking']['id'])));
+        }
+
+        if (isset($data['factuurDatum'])) {
+            $inkoopfactuur->setFactuurDatum(new DateTimeImmutable($data['factuurDatum']));
+        }
+        if (isset($data['factuurBedrag'])) {
+            $inkoopfactuur->setFactuurBedrag($this->getMoney($data['factuurBedrag']));
+        }
+        if (isset($data['openstaandSaldo'])) {
+            $inkoopfactuur->setOpenstaandSaldo($this->getMoney($data['openstaandSaldo']));
+        }
+        if (isset($data['vervalDatum'])) {
+            $inkoopfactuur->setVervalDatum(new DateTimeImmutable($data['vervalDatum']));
+        }
+
+        return $inkoopfactuur;
+    }
+
     protected function mapBoekingResult(Model\Boeking $boeking, array $data = []): Model\Boeking
     {
         $data = empty($data) ? $this->responseData : $data;
@@ -242,6 +278,8 @@ final class BoekingMapper extends AbstractMapper
                 yield $this->mapVerkoopboekingResult(new $className, $boekingData);
             } else if ($className === Model\Verkoopfactuur::class) {
                 yield $this->mapVerkoopfactuurResult(new $className, $boekingData);
+            } else if ($className === Model\Inkoopfactuur::class) {
+                yield $this->mapInkoopfactuurResult(new $className, $boekingData);
             }
         }
     }

--- a/src/Mapper/V2/BoekingMapper.php
+++ b/src/Mapper/V2/BoekingMapper.php
@@ -48,6 +48,12 @@ final class BoekingMapper extends AbstractMapper
         return $this->mapInkoopboekingResult(new Model\Inkoopboeking());
     }
 
+    public function updateInkoopboeking(ResponseInterface $response): Model\Inkoopboeking
+    {
+        $this->setResponseData($response);
+        return $this->mapInkoopboekingResult(new Model\Inkoopboeking());
+    }
+
     public function addVerkoopboeking(ResponseInterface $response): Model\Verkoopboeking
     {
         $this->setResponseData($response);

--- a/src/Mapper/V2/BoekingMapper.php
+++ b/src/Mapper/V2/BoekingMapper.php
@@ -146,7 +146,6 @@ final class BoekingMapper extends AbstractMapper
         // This maps "id", "uri", "modifiedOn" and "factuurnummer".
         $verkoopfactuur = $this->mapArrayDataToModel($verkoopfactuur, $data);
 
-
         if (isset($data['relatie'])) {
             $verkoopfactuur->setRelatie(Model\Relatie::createFromUUID(Uuid::fromString($data['relatie']['id'])));
         }
@@ -231,7 +230,7 @@ final class BoekingMapper extends AbstractMapper
                     ->setBedrag($this->getMoney($boekingsregel["bedrag"]))
                     ->setBtwSoort(new Type\BtwSoort($boekingsregel["btwSoort"]));
 
-                if (isset($boekingsregel["omschrijving"]) && $boekingsregel["omschrijving"] !== null) {
+                if (isset($boekingsregel["omschrijving"])) {
                     $boekingsregelObject->setOmschrijving($boekingsregel["omschrijving"]);
                 }
 

--- a/src/Mapper/V2/BoekingMapper.php
+++ b/src/Mapper/V2/BoekingMapper.php
@@ -7,6 +7,7 @@
 
 namespace SnelstartPHP\Mapper\V2;
 
+use DateTimeImmutable;
 use function array_map;
 use Psr\Http\Message\ResponseInterface;
 use Ramsey\Uuid\Uuid;
@@ -42,6 +43,12 @@ final class BoekingMapper extends AbstractMapper
         yield from $this->mapManyResultsToSubMappers(Model\Verkoopboeking::class);
     }
 
+    public function findAllVerkoopfacturen(ResponseInterface $response): \Generator
+    {
+        $this->setResponseData($response);
+        return $this->mapManyResultsToSubMappers(Model\Verkoopfactuur::class);
+    }
+
     public function addInkoopboeking(ResponseInterface $response): Model\Inkoopboeking
     {
         $this->setResponseData($response);
@@ -52,6 +59,12 @@ final class BoekingMapper extends AbstractMapper
     {
         $this->setResponseData($response);
         return $this->mapInkoopboekingResult(new Model\Inkoopboeking());
+    }
+
+    public function updateVerkoopboeking(ResponseInterface $response): Model\Verkoopboeking
+    {
+        $this->setResponseData($response);
+        return $this->mapVerkoopboekingResult(new Model\Verkoopboeking());
     }
 
     public function addVerkoopboeking(ResponseInterface $response): Model\Verkoopboeking
@@ -120,6 +133,37 @@ final class BoekingMapper extends AbstractMapper
         return $verkoopboeking;
     }
 
+    protected function mapVerkoopfactuurResult(Model\Verkoopfactuur $verkoopfactuur, array $data = []): Model\Verkoopfactuur
+    {
+        $data = empty($data) ? $this->responseData : $data;
+
+        // This maps "id", "uri", "modifiedOn" and "factuurnummer".
+        $verkoopfactuur = $this->mapArrayDataToModel($verkoopfactuur, $data);
+
+
+        if (isset($data['relatie'])) {
+            $verkoopfactuur->setRelatie(Model\Relatie::createFromUUID(Uuid::fromString($data['relatie']['id'])));
+        }
+        if (isset($data['verkoopBoeking'])) {
+            $verkoopfactuur->setVerkoopBoeking(Model\Verkoopboeking::createFromUUID(Uuid::fromString($data['verkoopBoeking']['id'])));
+        }
+
+        if (isset($data['factuurDatum'])) {
+            $verkoopfactuur->setFactuurDatum(new DateTimeImmutable($data['factuurDatum']));
+        }
+        if (isset($data['factuurBedrag'])) {
+            $verkoopfactuur->setFactuurBedrag($this->getMoney($data['factuurBedrag']));
+        }
+        if (isset($data['openstaandSaldo'])) {
+            $verkoopfactuur->setOpenstaandSaldo($this->getMoney($data['openstaandSaldo']));
+        }
+        if (isset($data['vervalDatum'])) {
+            $verkoopfactuur->setVervalDatum(new DateTimeImmutable($data['vervalDatum']));
+        }
+
+        return $verkoopfactuur;
+    }
+
     protected function mapBoekingResult(Model\Boeking $boeking, array $data = []): Model\Boeking
     {
         $data = empty($data) ? $this->responseData : $data;
@@ -148,9 +192,12 @@ final class BoekingMapper extends AbstractMapper
         if (isset($data["boekingsregels"])) {
             $boeking->setBoekingsregels(...array_map(function(array $boekingsregel): Model\Boekingsregel {
                 $boekingsregelObject = (new Model\Boekingsregel())
-                    ->setOmschrijving($boekingsregel["omschrijving"])
                     ->setBedrag($this->getMoney($boekingsregel["bedrag"]))
                     ->setBtwSoort(new Type\BtwSoort($boekingsregel["btwSoort"]));
+
+                if (isset($boekingsregel["omschrijving"]) && $boekingsregel["omschrijving"] !== null) {
+                    $boekingsregelObject->setOmschrijving($boekingsregel["omschrijving"]);
+                }
 
                 if (isset($boekingsregel["grootboek"])) {
                     $boekingsregelObject
@@ -193,6 +240,8 @@ final class BoekingMapper extends AbstractMapper
                 yield $this->mapInkoopboekingResult(new $className, $boekingData);
             } else if ($className === Model\Verkoopboeking::class) {
                 yield $this->mapVerkoopboekingResult(new $className, $boekingData);
+            } else if ($className === Model\Verkoopfactuur::class) {
+                yield $this->mapVerkoopfactuurResult(new $className, $boekingData);
             }
         }
     }

--- a/src/Model/V2/Boeking.php
+++ b/src/Model/V2/Boeking.php
@@ -256,33 +256,4 @@ abstract class Boeking extends SnelstartObject
 
         return $this;
     }
-
-    /**
-     * @internal TODO: The API already validates the boeking is in balance. We
-     *                 don't need to duplicate that complicated logic here. The
-     *                 logic is broken anyway because it checks if the target
-     *                 amount is zero, while it  should check that the target
-     *                 amount is not zero. Simply negating the check doesn't
-     *                 resolve the issue either, because the factuurbedrag
-     *                 includes VAT/taxes and the boekingsregels do not, so we
-     *                 would also have to sum up all those.
-     *
-     * @deprecated SnelStart API already validates the boeking is in balance,
-     *             manual checks are not needed.
-     */
-    public function assertInBalance(): void
-    {
-        $targetAmount = $this->getFactuurbedrag();
-
-        /**
-         * @var Boekingsregel $boekingsregel
-         */
-        foreach ($this->getBoekingsregels() as $boekingsregel) {
-            $targetAmount->subtract($boekingsregel->getBedrag());
-        }
-
-        if ($targetAmount->isZero()) {
-            throw new BookingNotInBalanceException();
-        }
-    }
 }

--- a/src/Model/V2/Boeking.php
+++ b/src/Model/V2/Boeking.php
@@ -257,6 +257,19 @@ abstract class Boeking extends SnelstartObject
         return $this;
     }
 
+    /**
+     * @internal TODO: The API already validates the boeking is in balance. We
+     *                 don't need to duplicate that complicated logic here. The
+     *                 logic is broken anyway because it checks if the target
+     *                 amount is zero, while it  should check that the target
+     *                 amount is not zero. Simply negating the check doesn't
+     *                 resolve the issue either, because the factuurbedrag
+     *                 includes VAT/taxes and the boekingsregels do not, so we
+     *                 would also have to sum up all those.
+     *
+     * @deprecated SnelStart API already validates the boeking is in balance,
+     *             manual checks are not needed.
+     */
     public function assertInBalance(): void
     {
         $targetAmount = $this->getFactuurbedrag();
@@ -268,7 +281,7 @@ abstract class Boeking extends SnelstartObject
             $targetAmount->subtract($boekingsregel->getBedrag());
         }
 
-        if (!$targetAmount->isZero()) {
+        if ($targetAmount->isZero()) {
             throw new BookingNotInBalanceException();
         }
     }

--- a/src/Model/V2/Boeking.php
+++ b/src/Model/V2/Boeking.php
@@ -268,7 +268,7 @@ abstract class Boeking extends SnelstartObject
             $targetAmount->subtract($boekingsregel->getBedrag());
         }
 
-        if ($targetAmount->isZero()) {
+        if (!$targetAmount->isZero()) {
             throw new BookingNotInBalanceException();
         }
     }

--- a/src/Model/V2/Boeking.php
+++ b/src/Model/V2/Boeking.php
@@ -80,7 +80,7 @@ abstract class Boeking extends SnelstartObject
      * @see Boekingsregel
      * @var Boekingsregel[]
      */
-    protected $boekingsregels;
+    protected $boekingsregels = [];
 
     /**
      * De af te dragen btw van de boeking per btw-tarief

--- a/src/Secure/AccessToken.php
+++ b/src/Secure/AccessToken.php
@@ -6,8 +6,6 @@
 
 namespace SnelstartPHP\Secure;
 
-use DateTime;
-use DateTimeZone;
 use SnelstartPHP\Secure\BearerToken\BearerTokenInterface;
 
 final class AccessToken implements \JsonSerializable
@@ -52,7 +50,7 @@ final class AccessToken implements \JsonSerializable
 
     private function getCurrentUtcTimestamp(): int
     {
-        return (new DateTime('now', new DateTimeZone('UTC')))->getTimestamp();
+        return (new \DateTime('now', new \DateTimeZone('UTC')))->getTimestamp();
     }
 
     public function getExpiresIn(): int


### PR DESCRIPTION
During the development of an integration with out software and the Snelstart API using this package, we encountered a couple of issues and missing features. Forking was the quickest solution for us during development, but now that we're done it's time to merge these changes back. If you'd rather have these changes as separate PR's, let me know.

Summary of changes:
BoekingConnector::findInkoopfacturen() now correctly returns inkoopfacturen instead of inkoopboekingen
BoekingConnector::findVerkoopfacturen() now correctly returns verkoopfacturen instead of verkoopboekingen

added BoekingConnector::updateInkoopboeking()
added BoekingConnector::updateVerkoopboeking()

Fix KostenplaatsConnector::update() incorrectly throwing a shouldHaveAnIdException. I believe VerkooporderConnector::delete() and KostenplaatsConnector::delete() have the same mistake, but I didn't encounter them personally so have not touched those.

The field "omschrijving" is not required for a Boekingsregel en thus may be NULL, but the setter (which is type-hinted to string) was always called, resulting in an error.

Boeking::assertInBalance() is incorrect and unnecessary, because the API already validates this. I've removed this method and calls to it in V2. I'm not sure about V1.

According to my commit message from 6 months ago, time() did not return a UTC timestamp but relied on the system timezone. But according to a [heavily upvoted comment on php.net](https://www.php.net/manual/en/function.time.php#100220), time() actually does return a UTC timezone regardless of server timezone. I don't know what I was on 6 months ago that lead me to that conclusion, but I'm fairly certain I didn't do it without reason. Using DateTime and DateTimeZone('UTC') is more explicit and therefore more clear IMO and I've verified it to work.

Added a margin to compensate for the difference in timing between servers and to account for the time network calls may take. It's not 100% bullet proof of course, but should prevent the majority of cases where isExpired returns false, but the API call results in an access token expired error.

