### PR TITLE
Set a default value for extraVeldenKlant

### DIFF
--- a/src/Model/V2/Relatie.php
+++ b/src/Model/V2/Relatie.php
@@ -226,7 +226,7 @@ final class Relatie extends SnelstartObject
     /**
      * @var NaamWaarde[]
      */
-    private $extraVeldenKlant;
+    private $extraVeldenKlant = [];
 
     /**
      * @var string[]


### PR DESCRIPTION
This fixes the following error fetching a relatie from SnelStart:
`SnelstartPHP\Model\V2\Relatie::getExtraVeldenKlant(): Return value must be of type array, null returned`