### PR TITLE
Allow moneyphp/money version 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.3|7.*",
-        "moneyphp/money": "^3.0",
+        "moneyphp/money": "^3.0|^4.0",
         "myclabs/php-enum": "^1.6",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
This also removes deprecation warnings on PHP 8.1.