### PR TITLE
Allow psr/cache version 2.0 & 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^6.3|7.*",
         "moneyphp/money": "^3.0|^4.0",
         "myclabs/php-enum": "^1.6",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8|^4.0"


### PR DESCRIPTION
I needed to update these packages in order to get the package working with the latest Symfony pacakges