### PR TITLE
Replace json_encode() method with Utils::jsonEncode method

### DIFF
--- a/src/Request/V2/BoekingRequest.php
+++ b/src/Request/V2/BoekingRequest.php
@@ -3,6 +3,7 @@
 namespace SnelstartPHP\Request\V2;
 
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Ramsey\Uuid\UuidInterface;
 use SnelstartPHP\Exception\PreValidationException;
@@ -25,7 +26,7 @@ final class BoekingRequest extends BaseRequest
     {
         return new Request("POST", "inkoopboekingen", [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($inkoopboeking)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($inkoopboeking)));
     }
 
     public function updateInkoopboeking(Model\Inkoopboeking $inkoopboeking): RequestInterface
@@ -36,14 +37,14 @@ final class BoekingRequest extends BaseRequest
 
         return new Request("PUT", "inkoopboekingen/" . $inkoopboeking->getId()->toString(), [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($inkoopboeking)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($inkoopboeking)));
     }
 
     public function addVerkoopboeking(Model\Verkoopboeking $verkoopboeking): RequestInterface
     {
         return new Request("POST", "verkoopboekingen", [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($verkoopboeking)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($verkoopboeking)));
     }
 
     public function updateVerkoopboeking(Model\Verkoopboeking $verkoopboeking): RequestInterface
@@ -54,7 +55,7 @@ final class BoekingRequest extends BaseRequest
 
         return new Request("PUT", "verkoopboekingen/" . $verkoopboeking->getId()->toString(), [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($verkoopboeking)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($verkoopboeking)));
     }
 
     /**

--- a/src/Request/V2/DocumentRequest.php
+++ b/src/Request/V2/DocumentRequest.php
@@ -3,6 +3,7 @@
 namespace SnelstartPHP\Request\V2;
 
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Ramsey\Uuid\UuidInterface;
 use SnelstartPHP\Exception\PreValidationException;
@@ -60,7 +61,7 @@ final class DocumentRequest extends BaseRequest
 
         return new Request("PUT", "documenten/" . $document->getId()->toString(), [
             "Content-Type"  =>  "application/json",
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($document)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($document)));
     }
 
     public function deleteDocument(Document $document): RequestInterface
@@ -76,6 +77,6 @@ final class DocumentRequest extends BaseRequest
     {
         return new Request("POST", sprintf("documenten/%s", $documentType->getValue()), [
             "Content-Type" =>   "application/json",
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($document)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($document)));
     }
 }

--- a/src/Request/V2/GrootboekRequest.php
+++ b/src/Request/V2/GrootboekRequest.php
@@ -8,6 +8,7 @@
 namespace SnelstartPHP\Request\V2;
 
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Ramsey\Uuid\UuidInterface;
 use SnelstartPHP\Exception\PreValidationException;
@@ -31,7 +32,7 @@ final class GrootboekRequest extends BaseRequest
     {
         return new Request("POST", "grootboeken", [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($grootboek)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($grootboek)));
     }
 
     public function update(Model\Grootboek $grootboek): RequestInterface
@@ -42,6 +43,6 @@ final class GrootboekRequest extends BaseRequest
 
         return new Request("PUT", "grootboeken/" . $grootboek->getId()->toString(), [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($grootboek)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($grootboek)));
     }
 }

--- a/src/Request/V2/VerkooporderRequest.php
+++ b/src/Request/V2/VerkooporderRequest.php
@@ -7,6 +7,7 @@
 namespace SnelstartPHP\Request\V2;
 
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use SnelstartPHP\Exception\PreValidationException;
 use SnelstartPHP\Model\V2\Verkooporder;
@@ -18,7 +19,7 @@ final class VerkooporderRequest extends BaseRequest
     {
         return new Request("POST", "verkooporders", [
             "Content-Type"  =>  "application/json"
-        ], \GuzzleHttp\json_encode($this->prepareAddOrEditRequestForSerialization($verkooporder)));
+        ], Utils::jsonEncode($this->prepareAddOrEditRequestForSerialization($verkooporder)));
     }
 
     public function delete(Verkooporder $verkooporder): RequestInterface

--- a/tests/Request/V2/BoekingRequestTest.php
+++ b/tests/Request/V2/BoekingRequestTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SnelstartPHP\Tests\Request\V2;
+
+use Money\Currency;
+use Money\Money;
+use Ramsey\Uuid\Uuid;
+use SnelstartPHP\Model\V2\Inkoopboeking;
+use SnelstartPHP\Request\V2\BoekingRequest;
+use PHPUnit\Framework\TestCase;
+
+class BoekingRequestTest extends TestCase
+{
+    private $boekingRequest;
+
+    public function setUp(): void
+    {
+        $this->boekingRequest = new BoekingRequest();
+    }
+
+    public function testAddInkoopboeking(): void
+    {
+        $uuid = Uuid::uuid4();
+
+        $inkoopboeking = Inkoopboeking::createFromUUID($uuid);
+        $inkoopboeking->setFactuurnummer('123456');
+        $inkoopboeking->setFactuurbedrag(new Money(2000, new Currency('EUR')));
+
+        $expected = [
+            "id" => $uuid->toString(),
+            "boekstuk" => null,
+            "gewijzigdDoorAccountant" => false,
+            "markering" => false,
+            "factuurDatum" => null,
+            "factuurnummer" => "123456",
+            "omschrijving" => null,
+            "factuurBedrag" => "20.00",
+            "boekingsregels" => [],
+            "vervalDatum" => null,
+            "btw" => [],
+            "documents" =>[],
+            "leverancier" =>null,
+        ];
+        $request = $this->boekingRequest->addInkoopboeking($inkoopboeking);
+
+        $this->assertEquals('POST', $request->getMethod());
+
+        $this->assertEquals('inkoopboekingen', $request->getUri());
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expected),
+            $request->getBody()->getContents()
+        );
+    }
+}

--- a/tests/Request/V2/GrootboekRequestTest.php
+++ b/tests/Request/V2/GrootboekRequestTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SnelstartPHP\Tests\Request\V2;
+
+use Ramsey\Uuid\Uuid;
+use SnelstartPHP\Exception\PreValidationException;
+use SnelstartPHP\Model\V2\Grootboek;
+use SnelstartPHP\Request\V2\GrootboekRequest;
+use PHPUnit\Framework\TestCase;
+
+class GrootboekRequestTest extends TestCase
+{
+    private $grootboekRequest;
+
+    public function setUp(): void
+    {
+        $this->grootboekRequest = new GrootboekRequest();
+    }
+
+    public function testAddSuccessful(): void
+    {
+        $uuid = Uuid::uuid4();
+
+        $grootboek = Grootboek::createFromUUID($uuid);
+
+        $expected = [
+            "id" => $uuid->toString(),
+        ];
+        $request = $this->grootboekRequest->add($grootboek);
+
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('grootboeken', $request->getUri());
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expected),
+            $request->getBody()->getContents()
+        );
+    }
+
+    public function testUpdateSuccessful(): void
+    {
+        $uuid = Uuid::uuid4();
+
+        $grootboek = Grootboek::createFromUUID($uuid);
+
+        $expected = [
+            "id" => $uuid->toString(),
+        ];
+        $request = $this->grootboekRequest->update($grootboek);
+
+        $this->assertEquals('PUT', $request->getMethod());
+        $this->assertEquals(sprintf('%s/%s', 'grootboeken', $uuid->toString()), $request->getUri());
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expected),
+            $request->getBody()->getContents()
+        );
+    }
+
+    public function testUpdateWithException(): void
+    {
+        $this->expectException(PreValidationException::class);
+
+        $grootboek = new Grootboek();
+
+        $this->grootboekRequest->update($grootboek);
+    }
+}


### PR DESCRIPTION
As stated in the functions.php file of http guzzle the `json_decode()` method will be removed in `guzzlehttp/guzzle:8.0`. We used `Utils::jsonDecode` instead.