### PR TITLE
Allow support of the latest version of phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "dg/bypass-finals": "^1.1",
         "phpstan/phpstan": "^1.5",
-        "phpunit/phpunit": "^8.4",
+        "phpunit/phpunit": "^8.4|^9.5",
         "vimeo/psalm": "^4.0"
     },
     "suggest": {


### PR DESCRIPTION
I notice the composer.json did not support the latest version of phpunit. It's nice it this version is supported for future use.