### PR TITLE
Allow support of the latest version of psr/log library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "myclabs/php-enum": "^1.6",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "ramsey/uuid": "^3.8|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Most of the other (symfony) libraries are supporting the latest `psr/log` library. It's easy if this library also support the latest version. This way the update path to the latest version of your symfony project will be easier.