### PR TITLE
Added VerkoopOrderStatus for VerkoopOrder model

### DIFF
--- a/src/Mapper/V2/VerkooporderMapper.php
+++ b/src/Mapper/V2/VerkooporderMapper.php
@@ -14,6 +14,7 @@ use SnelstartPHP\Model\IncassoMachtiging;
 use SnelstartPHP\Model\Kostenplaats;
 use SnelstartPHP\Model\Type\ProcesStatus;
 use SnelstartPHP\Model\Type\VerkooporderBtwIngave;
+use SnelstartPHP\Model\Type\VerkooporderStatus;
 use SnelstartPHP\Model\V2\Artikel;
 use SnelstartPHP\Model\V2\Relatie;
 use SnelstartPHP\Model\V2\Verkoopfactuur;
@@ -98,6 +99,10 @@ final class VerkooporderMapper extends AbstractMapper
 
         if ($data["verkooporderBtwIngaveModel"] !== null) {
             $verkooporder->setVerkooporderBtwIngaveModel(VerkooporderBtwIngave::from($data["verkooporderBtwIngaveModel"]));
+        }
+
+        if ($data["verkoopOrderStatus"] !== null) {
+            $verkooporder->setVerkooporderStatus(new VerkooporderStatus($data["verkoopOrderStatus"]));
         }
 
         return $verkooporder;

--- a/src/Model/Type/VerkooporderStatus.php
+++ b/src/Model/Type/VerkooporderStatus.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author  OptiWise Technologies B.V. <info@optiwise.nl>
+ * @project SnelstartApiPHP
+ */
+
+namespace SnelstartPHP\Model\Type;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @psalm-immutable
+ *
+ * @method static VerkooporderStatus INBEHANDELING()
+ * @method static VerkooporderStatus UITGEVOERD()
+ * @method static VerkooporderStatus SERVICE()
+ */
+class VerkooporderStatus extends Enum
+{
+    private const INBEHANDELING = 'InBehandeling';
+
+    private const UITGEVOERD = 'Uitgevoerd';
+
+    private const SERVICE = 'Service';
+}

--- a/src/Model/V2/Verkooporder.php
+++ b/src/Model/V2/Verkooporder.php
@@ -13,6 +13,7 @@ use SnelstartPHP\Model\Kostenplaats;
 use SnelstartPHP\Model\SnelstartObject;
 use SnelstartPHP\Model\Type\ProcesStatus;
 use SnelstartPHP\Model\Type\VerkooporderBtwIngave;
+use SnelstartPHP\Model\Type\VerkooporderStatus;
 use SnelstartPHP\Snelstart;
 
 final class Verkooporder extends SnelstartObject
@@ -150,6 +151,13 @@ final class Verkooporder extends SnelstartObject
     private $totaalInclusiefBtw;
 
     /**
+     * Status van de order. Als deze niet is opgegeven wordt de default waarde InBehandeling gebruikt.
+     *
+     * @var VerkooporderStatus|null
+     */
+    private $verkoopOrderStatus;
+
+    /**
      * @var string[]
      */
     public static $editableAttributes = [
@@ -174,6 +182,7 @@ final class Verkooporder extends SnelstartObject
         "verkoopordersjabloon",
         "totaalExclusiefBtw",
         "totaalInclusiefBtw",
+        "verkoopOrderStatus",
     ];
 
     public static function getEditableAttributes(): array
@@ -434,6 +443,18 @@ final class Verkooporder extends SnelstartObject
     public function setTotaalInclusiefBtw(Money $totaalInclusiefBtw): self
     {
         $this->totaalInclusiefBtw = $totaalInclusiefBtw;
+
+        return $this;
+    }
+
+    public function getVerkoopOrderStatus(): ?VerkooporderStatus
+    {
+        return $this->verkoopOrderStatus;
+    }
+
+    public function setVerkoopOrderStatus(?VerkooporderStatus $verkoopOrderStatus): self
+    {
+        $this->verkoopOrderStatus = $verkoopOrderStatus;
 
         return $this;
     }

--- a/tests/Request/V2/VerkooporderRequestTest.php
+++ b/tests/Request/V2/VerkooporderRequestTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SnelstartPHP\Tests\Request\V2;
+
+use PHPUnit\Framework\TestCase;
+use SnelstartPHP\Model\Type\VerkooporderStatus;
+use SnelstartPHP\Model\V2\Verkooporder;
+use SnelstartPHP\Request\V2\VerkooporderRequest;
+
+class VerkooporderRequestTest extends TestCase
+{
+    private $verkooporderRequest;
+
+    public function setUp(): void {
+        $this->verkooporderRequest = new VerkooporderRequest();
+    }
+
+    public function testAddVerkooporderHasVerkooporderStatusUitgevoerd(): void {
+        $verkooporder = new Verkooporder();
+        $verkooporder->setVerkooporderStatus(VerkooporderStatus::UITGEVOERD());
+
+        $expected = [
+            "relatie" => null,
+            "procesStatus" => null,
+            "nummer" => null,
+            "modifiedOn" => null,
+            "datum" => null,
+            "krediettermijn" => null,
+            "omschrijving" => null,
+            "betalingskenmerk" => null,
+            "incassomachtiging" => null,
+            "afleveradres" => null,
+            "factuuradres" => null,
+            "verkooporderBtwIngaveModel" => null,
+            "kostenplaats" => null,
+            "regels" => null,
+            "memo" => null,
+            "orderreferentie" => null,
+            "factuurkorting" => null,
+            "verkoopfactuur" => null,
+            "verkoopordersjabloon" => null,
+            "totaalExclusiefBtw" => "0.00",
+            "totaalInclusiefBtw" => "0.00",
+            "verkoopOrderStatus" => VerkooporderStatus::UITGEVOERD()->getValue(),
+        ];
+        $request = $this->verkooporderRequest->add($verkooporder);
+
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals(json_encode($expected), $request->getBody()->getContents());
+    }
+}

--- a/var/doc/v2/verkooporder_add.php
+++ b/var/doc/v2/verkooporder_add.php
@@ -49,6 +49,7 @@ $verkooporder
     ->setKrediettermijn(14)
     ->setOmschrijving("Week 50")
     ->setRegels(...$lines)
+    ->setVerkooporderStatus(\SnelstartPHP\Model\Type\VerkooporderStatus::UITGEVOERD())
 ;
 
 $verkoopboekingConnector = new \SnelstartPHP\Connector\V2\VerkooporderConnector($connection);


### PR DESCRIPTION
Hi, 

This PR aims to address the missing `VerkoopOrderStatus` in the `VerkoopOrder` model as described in #38.

