### PR TITLE
Update code to php 7.4 using rector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+rector:
+	vendor/bin/rector process src
+
+rector-dry:
+	vendor/bin/rector process src --dry-run

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.4|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require-dev": {
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.5.23",
+        "rector/rector": "^0.17.1",
         "vimeo/psalm": "^4.0|^5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.4|^7.0",

--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
 
     // define sets of rules
-    //    $rectorConfig->sets([
-    //        LevelSetList::UP_TO_PHP_72
-    //    ]);
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_72
+    ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    // register a single rule
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    // define sets of rules
+    //    $rectorConfig->sets([
+    //        LevelSetList::UP_TO_PHP_72
+    //    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -17,6 +17,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     // define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_72
+        LevelSetList::UP_TO_PHP_73,
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -17,6 +20,12 @@ return static function (RectorConfig $rectorConfig): void {
 
     // define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_73,
+        LevelSetList::UP_TO_PHP_74,
+    ]);
+
+    $rectorConfig->skip([
+        TypedPropertyFromAssignsRector::class,
+        NullCoalescingOperatorRector::class, // https://wiki.php.net/rfc/null_coalesce_equal_operator
+        ClosureToArrowFunctionRector::class, // https://wiki.php.net/rfc/arrow_functions_v2
     ]);
 };

--- a/src/Exception/SnelstartApiErrorException.php
+++ b/src/Exception/SnelstartApiErrorException.php
@@ -11,7 +11,7 @@ final class SnelstartApiErrorException extends \RuntimeException
     public static function handleError(array $body): self
     {
         if (isset($body["modelState"])) {
-            $errorMessages = [ sprintf("%d validation failures occurred.", \count($body["modelState"])) ];
+            $errorMessages = [ sprintf("%d validation failures occurred.", is_array($body["modelState"]) || $body["modelState"] instanceof \Countable ? \count($body["modelState"]) : 0) ];
 
             foreach ($body["modelState"] as $field => $modelStateErrors) {
                 $errorMessages[] = $field . ": ";

--- a/src/Exception/SnelstartApiErrorException.php
+++ b/src/Exception/SnelstartApiErrorException.php
@@ -11,7 +11,7 @@ final class SnelstartApiErrorException extends \RuntimeException
     public static function handleError(array $body): self
     {
         if (isset($body["modelState"])) {
-            $errorMessages = [ sprintf("%d validation failures occurred.", is_array($body["modelState"]) || $body["modelState"] instanceof \Countable ? \count($body["modelState"]) : 0) ];
+            $errorMessages = [ sprintf("%d validation failures occurred.", is_countable($body["modelState"]) ? \count($body["modelState"]) : 0) ];
 
             foreach ($body["modelState"] as $field => $modelStateErrors) {
                 $errorMessages[] = $field . ": ";
@@ -39,6 +39,6 @@ final class SnelstartApiErrorException extends \RuntimeException
             return new static($body["Message"] ?? $body["message"], 400);
         }
 
-        throw new static("Unknown exception. Message body: " . \json_encode($body), 400);
+        throw new static("Unknown exception. Message body: " . \json_encode($body, JSON_THROW_ON_ERROR), 400);
     }
 }

--- a/src/Request/ODataRequestData.php
+++ b/src/Request/ODataRequestData.php
@@ -24,12 +24,12 @@ final class ODataRequestData implements ODataRequestDataInterface
     /**
      * @var int
      */
-    private $top;
+    private $top = Snelstart::MAX_RESULTS;
 
     /**
      * @var int
      */
-    private $skip;
+    private $skip = 0;
 
     /**
      * @var string
@@ -48,8 +48,6 @@ final class ODataRequestData implements ODataRequestDataInterface
 
     public function __construct()
     {
-        $this->top = Snelstart::MAX_RESULTS;
-        $this->skip = 0;
     }
 
     public function getFilter(): array

--- a/src/Secure/CachedAccessTokenConnection.php
+++ b/src/Secure/CachedAccessTokenConnection.php
@@ -79,6 +79,6 @@ final class CachedAccessTokenConnection
 
     protected function getItemKey(): string
     {
-        return self::CACHE_ITEM_PREFIX . \spl_object_hash($this) . mt_rand(0, 99);
+        return self::CACHE_ITEM_PREFIX . \spl_object_hash($this) . random_int(0, 99);
     }
 }


### PR DESCRIPTION
The following rules are skipped:
 - TypedPropertyFromAssignsRector::class,
 - NullCoalescingOperatorRector::class, // https://wiki.php.net/rfc/null_coalesce_equal_operator
 - ClosureToArrowFunctionRector::class, // https://wiki.php.net/rfc/arrow_functions_v2

We can apply each rule in one single MR. Which rules do we want to apply next?
