### PR TITLE
Mapping "extraVelden" to Artikel.

### DIFF
--- a/src/Mapper/V2/ArtikelMapper.php
+++ b/src/Mapper/V2/ArtikelMapper.php
@@ -74,6 +74,16 @@ final class ArtikelMapper extends AbstractMapper
             );
         }
 
+        if (!empty($data["extraVelden"])) {
+            $extraVelden = [];
+
+            foreach ($data["extraVelden"] as $extraVeld) {
+                $extraVelden[$extraVeld["naam"]] = $extraVeld["waarde"];
+            }
+
+            $artikel->setExtraVelden($extraVelden);
+        }
+
         return $artikel;
     }
 

--- a/src/Model/V2/Artikel.php
+++ b/src/Model/V2/Artikel.php
@@ -89,6 +89,11 @@ final class Artikel extends SnelstartObject
     private $vrijeVoorraad;
 
     /**
+     * @var array<string, mixed>
+     */
+    private $extraVelden = [];
+
+    /**
      * @var string[]
      */
     public static $editableAttributes = [
@@ -247,6 +252,16 @@ final class Artikel extends SnelstartObject
         $this->vrijeVoorraad = $vrijeVoorraad;
 
         return $this;
+    }
+
+    public function getExtraVelden(): array
+    {
+        return $this->extraVelden;
+    }
+
+    public function setExtraVelden(array $extraVelden): void
+    {
+        $this->extraVelden = $extraVelden;
     }
 
     public function getInkoopprijs(): Money

--- a/tests/Mapper/V2/ArtikelMapper/ExtraVeldenTest.php
+++ b/tests/Mapper/V2/ArtikelMapper/ExtraVeldenTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Mapper\V2\ArtikelMapper;
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use SnelstartPHP\Mapper\V2\ArtikelMapper;
+use SnelstartPHP\Utils;
+
+class ExtraVeldenTest extends TestCase
+{
+    public function testExtraVeldenAreSetOnArtikel(): void
+    {
+        $artikelData = [
+            "extraVelden" => [
+                [
+                    "naam" => "Extra veld 1",
+                    "waarde" => "Test value",
+                ],
+                [
+                    "naam" => "Extra veld 2",
+                    "waarde" => 100,
+                ],
+                [
+                    "naam" => "Extra veld 3",
+                    "waarde" => true,
+                ],
+            ],
+        ];
+        $artikelResponse = new Response(200, [], Utils::jsonEncode($artikelData));
+
+        $artikel = (new ArtikelMapper())->find($artikelResponse);
+
+        $extraVelden = $artikel->getExtraVelden();
+
+        foreach ($artikelData["extraVelden"] as $extraVeld) {
+            $this->assertArrayHasKey($extraVeld["naam"], $extraVelden);
+            $this->assertEquals($extraVeld["waarde"], $extraVelden[$extraVeld["naam"]]);
+        }
+    }
+
+    public function testExtraVeldenAreEmptyIfNotGiven(): void
+    {
+        $artikelData = [];
+        $artikelResponse = new Response(200, [], Utils::jsonEncode($artikelData));
+
+        $artikel = (new ArtikelMapper())->find($artikelResponse);
+
+        $this->assertEmpty($artikel->getExtraVelden());
+    }
+}


### PR DESCRIPTION
This PR aims to add support for the "Extra Velden" on Artikelen.

See the following models in the API documentation:
[SnelStart.B2B.Api.V2.Models.Artikelen.ArtikelQueryModel](https://b2bapi-developer.snelstart.nl/api-details#api=5c18d0cdd21b99cfccdde8eb&operation=v2-artikelen-GET-OData&definition=SnelStart.B2B.Api.V2.Models.Artikelen.ArtikelQueryModel)
[SnelStart.B2B.Api.V2.Models.Artikelen.ExtraVeldArtikelModel](https://b2bapi-developer.snelstart.nl/api-details#api=5c18d0cdd21b99cfccdde8eb&operation=v2-artikelen-GET-OData&definition=SnelStart.B2B.Api.V2.Models.Artikelen.ExtraVeldArtikelModel)